### PR TITLE
#30 add issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yaml
@@ -1,0 +1,37 @@
+name: 🐞 Bug report
+description: File a bug report
+title: "[Bug]: "
+labels: ["bug"]
+body:
+- type: textarea
+  attributes:
+    label: Current Behavior
+    description: どんな不具合が出る？
+    placeholder: Tell us what you see!
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Expected Behavior
+    description: どんな動作を期待していた？
+    placeholder: Tell us what you expected!
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Steps To Reproduce
+    description: 不具合の再現方法
+    placeholder: |
+      1. In this environment...
+      2. With this config...
+      3. Run '...'
+      4. See error...
+- type: textarea
+  attributes:
+    label: Anything else?
+    description: |
+      Links? Reference? Anything that will give us more context about the issue you are encountering!
+
+      Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.
+  validations:
+    required: false

--- a/.github/ISSUE_TEMPLATE/new-feature.yaml
+++ b/.github/ISSUE_TEMPLATE/new-feature.yaml
@@ -1,0 +1,36 @@
+name: 🖊Feature request
+description: File a feature request
+title: "[New Feature]: "
+labels: ["enhancement"]
+body:
+- type: textarea
+  attributes:
+    label: Feature Request
+    description: 欲しい機能はなに？
+    placeholder: Tell us what you want!
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Reason For Request
+    description: なぜその機能が欲しい？
+    placeholder: Tell us why you want!
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Implementation Method
+    description: 実装方法
+    placeholder: |
+      1. Replacing class component...
+      2. Enhance the css...
+      3. Polish up the algorithm... 
+- type: textarea
+  attributes:
+    label: Anything else?
+    description: |
+      Links? Reference? Anything that will give us more context about the feature request!
+
+      Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.
+  validations:
+    required: false


### PR DESCRIPTION
GithubのIssueテンプレートを作成しました。
自分で作ったリポジトリで試したところ、masterブランチに置かないと反映されないようです。

参考：https://docs.github.com/ja/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms

こんな見た目です。
![image](https://user-images.githubusercontent.com/28249208/141459812-6561f56c-9ad3-4b2c-a952-9cd6a009502b.png)
![image](https://user-images.githubusercontent.com/28249208/141459840-b9ea9b3a-b301-4b00-806b-65325213dfe8.png)
![image](https://user-images.githubusercontent.com/28249208/141459881-25a94195-b061-4bb8-966a-c5681ec2c051.png)

close #30 
