### PR TITLE
Feature/#24 add time control function

### DIFF
--- a/src/Container.js
+++ b/src/Container.js
@@ -14,6 +14,8 @@ const Container = () => {
   const [borderSizeHeight, setBorderSizeHeight] = useState(6);
   const [borderSizeWidth, setBorderSizeWidth] = useState(7);
   const [victoryCondition, setVictoryCondition] = useState(4);
+  const [timeMinControl, setTimeMinControl] = useState(20);
+  const [timeSecControl, setTimeSecControl] = useState(0);
   const [playerName1, setPlayerName1] = useState("Player1");
   const [playerName2, setPlayerName2] = useState("Player2");
 
@@ -52,6 +54,10 @@ const Container = () => {
       setBorderSizeWidth(tempValue);
     } else if (name === "victoryCondition") {
       setVictoryCondition(tempValue);
+    } else if (name === "timeMinControl") {
+      setTimeMinControl(tempValue);
+    } else if (name === "timeSecControl") {
+      setTimeSecControl(tempValue);
     }
   };
 
@@ -72,6 +78,8 @@ const Container = () => {
               borderSizeHeight={borderSizeHeight}
               borderSizeWidth={borderSizeWidth}
               victoryCondition={victoryCondition}
+              timeMinControl={timeMinControl}
+              timeSecControl={timeSecControl}
               playerName1={playerName1}
               playerName2={playerName2}
               onPlayerNameChange={handleInputPlayerNameChange}
@@ -88,6 +96,8 @@ const Container = () => {
               victoryCondition={victoryCondition}
               playerName1={playerName1}
               playerName2={playerName2}
+              timeMinControl={timeMinControl}
+              timeSecControl={timeSecControl}
             />
           }
         ></Route>

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -2,6 +2,7 @@ import React from "react";
 import { Link } from "react-router-dom";
 import Button from "@mui/material/Button";
 
+// TODO: Yuki Ueno: ゲーム画面からホーム画面、設定画面に遷移する際にタイマーを停止する処理を追加する（参考：https://weblike-curtaincall.ssl-lolipop.jp/blog/?p=2056）
 const Header = () => {
   return (
     <header>

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -17,6 +17,9 @@ const style = {
 };
 
 const BasicModal = (props) => {
+  const playerName1 = props.playerName1;
+  const playerName2 = props.playerName2;
+
   return (
     <div>
       <Modal
@@ -29,10 +32,10 @@ const BasicModal = (props) => {
           {props.gameWinner !== "draw" ? (
             <>
               <Typography id="modal-modal-title" variant="h6" component="h2">
-                The winner is {props.gameWinner}
+                The winner is {props.gameWinner === "Player1" ? playerName1 : playerName2}
               </Typography>
               <Typography id="modal-modal-description" sx={{ mt: 2 }}>
-                Congratulations! {props.gameWinner} won the game!
+                Congratulations! {props.gameWinner === "Player1" ? playerName1 : playerName2} win the game!
               </Typography>
             </>
           ) : (

--- a/src/components/board/DisplayPlayerTurn.js
+++ b/src/components/board/DisplayPlayerTurn.js
@@ -1,6 +1,6 @@
 import React from "react";
 import Grid from "@mui/material/Grid";
-import Box from "@mui/material/Grid";
+import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
 
 const playerTurnStyle = {

--- a/src/pages/GameDisplayPage.js
+++ b/src/pages/GameDisplayPage.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useCallback, useRef } from "react";
 import "./GameDisplayPage.css";
 import Modal from "../components/Modal";
 import Button from "@mui/material/Button";
@@ -11,28 +11,93 @@ import createNewBoard from "../utils/createNewBoard";
 import canPutStone from "../utils/canPutStone";
 import getLowestEmptyYIndex from "../utils/getLowestEmptyYIndex";
 import calculateWinner from "../utils/calculateWinner";
+import displayTimer from "../utils/displayTimer";
 
 const InitButton = (props) => {
   return (
     <Button variant="contained" color="primary" style={{ height: "50px" }} onClick={props.onClick}>
-      New Game
+      Start New Game
     </Button>
   );
 };
 
 const GameDisplayPage = (props) => {
   const initBoard = createNewBoard(props.borderSizeWidth, props.borderSizeHeight);
+  const timeControl = (props.timeMinControl * 60 + props.timeSecControl) * 100; // 1/100秒単位のタイマー
+  const [count1, setCount1] = useState(timeControl);
+  const [count2, setCount2] = useState(timeControl);
   const [player1IsNext, setPlayer1IsNext] = useState(true);
   const [gameWinner, setGameWinner] = useState("");
   const [history, setHistory] = useState([
     {
       board: initBoard,
+      count1: timeControl,
+      count2: timeControl,
     },
   ]);
   const [stepNumber, setStepNumber] = useState(0);
   const [modalOpen, setModalOpen] = useState(false);
+  const [canStartGame, setCanStartGame] = useState(false);
   const handleModalOpen = () => setModalOpen(true);
   const handleModalClose = () => setModalOpen(false);
+
+  const intervalRef1 = useRef(null);
+  /**
+   * Player1のタイマーの開始
+   */
+  const startTimer1 = useCallback(() => {
+    if (intervalRef1.current !== null) {
+      return;
+    }
+    intervalRef1.current = setInterval(() => {
+      setCount1((c) => c - 1);
+    }, 10);
+  }, []);
+
+  /**
+   * Player1のタイマーの停止
+   */
+  const stopTimer1 = useCallback(() => {
+    if (intervalRef1.current === null) {
+      return;
+    }
+    clearInterval(intervalRef1.current);
+    intervalRef1.current = null;
+  }, []);
+
+  const intervalRef2 = useRef(null);
+  /**
+   * Player2のタイマーの開始
+   */
+  const startTimer2 = useCallback(() => {
+    if (intervalRef2.current !== null) {
+      return;
+    }
+    intervalRef2.current = setInterval(() => {
+      setCount2((c) => c - 1);
+    }, 10);
+  }, []);
+
+  /**
+   * Player2のタイマーの停止
+   */
+  const stopTimer2 = useCallback(() => {
+    if (intervalRef2.current === null) {
+      return;
+    }
+    clearInterval(intervalRef2.current);
+    intervalRef2.current = null;
+  }, []);
+
+  const controlTimer = (player1IsNext) => {
+    if (player1IsNext) {
+      startTimer1();
+      stopTimer2();
+    } else {
+      stopTimer1();
+      startTimer2();
+    }
+  };
 
   /**
    * ゲーム状態の初期化
@@ -41,11 +106,19 @@ const GameDisplayPage = (props) => {
     setHistory([
       {
         board: initBoard,
+        count1: timeControl,
+        count2: timeControl,
       },
     ]);
     setGameWinner("");
     setPlayer1IsNext(true);
     setStepNumber(0);
+    setCanStartGame(true);
+    setCount1(timeControl);
+    setCount2(timeControl);
+    stopTimer1();
+    stopTimer2();
+    startTimer1();
   };
 
   /**
@@ -54,7 +127,7 @@ const GameDisplayPage = (props) => {
    * @returns 複製した盤面を表す二次元配列
    */
   const copyBoard = (board) => {
-    let copiedBoard = [];
+    const copiedBoard = [];
     for (const array of board) {
       copiedBoard.push([...array]);
     }
@@ -69,10 +142,15 @@ const GameDisplayPage = (props) => {
   const copyHistory = (history) => {
     let copiedHistory = [];
     for (const historyItem of history) {
-      let board = historyItem.board;
-      let copiedBoard = copyBoard(board);
+      const board = historyItem.board;
+      const copiedBoard = copyBoard(board);
+      const copiedCount1 = historyItem.count1;
+      const copiedCount2 = historyItem.count2;
+
       copiedHistory.push({
         board: copiedBoard,
+        count1: copiedCount1,
+        count2: copiedCount2,
       });
     }
     return copiedHistory;
@@ -82,10 +160,15 @@ const GameDisplayPage = (props) => {
   const updateHistory = (history, step) => {
     let updatedHistory = [];
     for (let i = 0; i <= step; i++) {
-      let board = history[i].board;
-      let copiedBoard = copyBoard(board);
+      const board = history[i].board;
+      const copiedBoard = copyBoard(board);
+      const copiedCount1 = history[i].count1;
+      const copiedCount2 = history[i].count2;
+
       updatedHistory.push({
         board: copiedBoard,
+        count1: copiedCount1,
+        count2: copiedCount2,
       });
     }
     return updatedHistory;
@@ -110,6 +193,12 @@ const GameDisplayPage = (props) => {
     setPlayer1IsNext(step % 2 === 0);
     setHistory(updateHistory(history, step));
     setGameWinner("");
+    setCount1(history[step].count1);
+    setCount2(history[step].count2);
+    // player1IsNextの情報が即時反映されないため、一時的な変数を作成
+    // 関数内だとuseEffectが使えなかったため、この方法で対処した
+    const tempPlayer1IsNext = step % 2 === 0;
+    controlTimer(tempPlayer1IsNext);
   };
 
   const moves = history.map((_, index) => {
@@ -121,30 +210,50 @@ const GameDisplayPage = (props) => {
     );
   });
 
-  const current = history[stepNumber].board;
+  const currentBoard = history[stepNumber].board;
 
   const handleClick = (event) => {
     if (gameWinner !== "") return;
+
     const renewedHistory = copyHistory(history);
-    const current = renewedHistory[stepNumber].board;
-    let nextBoard = copyBoard(current);
+    const currentBoard = renewedHistory[stepNumber].board;
+    const nextBoard = copyBoard(currentBoard);
+    const copiedCount1 = count1;
+    const copiedCount2 = count2;
     const dataset = event.currentTarget.dataset;
     const x = parseInt(dataset.x);
 
     if (canPutStone(nextBoard, x)) {
-      let y = getLowestEmptyYIndex(nextBoard, x);
+      const y = getLowestEmptyYIndex(nextBoard, x);
       putStone(nextBoard, x, y);
-      //盤面の状態変更
-      setHistory(renewedHistory.concat([{ board: nextBoard }]));
-      //何手目かの状態変更
+      setHistory(
+        renewedHistory.concat([
+          {
+            board: nextBoard,
+            count1: copiedCount1,
+            count2: copiedCount2,
+          },
+        ])
+      );
       setStepNumber(stepNumber + 1);
-      // 勝利判定
+
       let winner = calculateWinner(nextBoard, props.victoryCondition, x, y);
+      if (count1 <= 0 && count2 > 0) {
+        winner = "Player2";
+      } else if (count2 <= 0 && count1 > 0) {
+        winner = "Player1";
+      }
       if (winner != null) {
         setGameWinner(winner);
+        console.log(gameWinner);
         handleModalOpen();
+        stopTimer1();
+        stopTimer2();
       } else if (winner == null) {
-        // プレイヤーを変更
+        // player1IsNextの情報が即時反映されないため、一時的な変数を作成
+        // 関数内・条件式内だとuseEffectが使えなかったため、この方法で対処した
+        const tempPlayer1IsNext = !player1IsNext;
+        controlTimer(tempPlayer1IsNext);
         setPlayer1IsNext(!player1IsNext);
       }
     }
@@ -158,8 +267,9 @@ const GameDisplayPage = (props) => {
       <Grid sx={{ display: "flex", justifyContent: "center", flexDirection: "row", alignItems: "flex-end", mb: 2 }}>
         <InitButton onClick={initGame} />
         <DisplayPlayerTurn playerTurn={player1IsNext} playerName1={props.playerName1} playerName2={props.playerName2} />
+        {displayTimer(count1)}/{displayTimer(count2)}
       </Grid>
-      <Board board={current} onClick={handleClick} />
+      <Board board={currentBoard} onClick={canStartGame ? handleClick : null} />
 
       {/* それぞれの手番の情報を表示する */}
       <Grid className="game-info">

--- a/src/pages/GameDisplayPage.js
+++ b/src/pages/GameDisplayPage.js
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useRef } from "react";
+import React, { useState } from "react";
 import "./GameDisplayPage.css";
 import Modal from "../components/Modal";
 import Button from "@mui/material/Button";
@@ -12,6 +12,7 @@ import canPutStone from "../utils/canPutStone";
 import getLowestEmptyYIndex from "../utils/getLowestEmptyYIndex";
 import calculateWinner from "../utils/calculateWinner";
 import displayTimer from "../utils/displayTimer";
+import useTimer from "../utils/useTimer";
 
 const InitButton = (props) => {
   return (
@@ -23,9 +24,9 @@ const InitButton = (props) => {
 
 const GameDisplayPage = (props) => {
   const initBoard = createNewBoard(props.borderSizeWidth, props.borderSizeHeight);
-  const timeControl = (props.timeMinControl * 60 + props.timeSecControl) * 100; // 1/100秒単位のタイマー
-  const [count1, setCount1] = useState(timeControl);
-  const [count2, setCount2] = useState(timeControl);
+  const timeControl = props.timeMinControl * 60 + props.timeSecControl;
+  const [count1, startTimer1, stopTimer1, resetTimer1, setTimer1] = useTimer(timeControl);
+  const [count2, startTimer2, stopTimer2, resetTimer2, setTimer2] = useTimer(timeControl);
   const [player1IsNext, setPlayer1IsNext] = useState(true);
   const [gameWinner, setGameWinner] = useState("");
   const [history, setHistory] = useState([
@@ -40,54 +41,6 @@ const GameDisplayPage = (props) => {
   const [canStartGame, setCanStartGame] = useState(false);
   const handleModalOpen = () => setModalOpen(true);
   const handleModalClose = () => setModalOpen(false);
-
-  const intervalRef1 = useRef(null);
-  /**
-   * Player1のタイマーの開始
-   */
-  const startTimer1 = useCallback(() => {
-    if (intervalRef1.current !== null) {
-      return;
-    }
-    intervalRef1.current = setInterval(() => {
-      setCount1((c) => c - 1);
-    }, 10);
-  }, []);
-
-  /**
-   * Player1のタイマーの停止
-   */
-  const stopTimer1 = useCallback(() => {
-    if (intervalRef1.current === null) {
-      return;
-    }
-    clearInterval(intervalRef1.current);
-    intervalRef1.current = null;
-  }, []);
-
-  const intervalRef2 = useRef(null);
-  /**
-   * Player2のタイマーの開始
-   */
-  const startTimer2 = useCallback(() => {
-    if (intervalRef2.current !== null) {
-      return;
-    }
-    intervalRef2.current = setInterval(() => {
-      setCount2((c) => c - 1);
-    }, 10);
-  }, []);
-
-  /**
-   * Player2のタイマーの停止
-   */
-  const stopTimer2 = useCallback(() => {
-    if (intervalRef2.current === null) {
-      return;
-    }
-    clearInterval(intervalRef2.current);
-    intervalRef2.current = null;
-  }, []);
 
   const controlTimer = (player1IsNext) => {
     if (player1IsNext) {
@@ -114,10 +67,10 @@ const GameDisplayPage = (props) => {
     setPlayer1IsNext(true);
     setStepNumber(0);
     setCanStartGame(true);
-    setCount1(timeControl);
-    setCount2(timeControl);
     stopTimer1();
     stopTimer2();
+    resetTimer1();
+    resetTimer2();
     startTimer1();
   };
 
@@ -193,8 +146,8 @@ const GameDisplayPage = (props) => {
     setPlayer1IsNext(step % 2 === 0);
     setHistory(updateHistory(history, step));
     setGameWinner("");
-    setCount1(history[step].count1);
-    setCount2(history[step].count2);
+    setTimer1(history[step].count1);
+    setTimer2(history[step].count2);
     // player1IsNextの情報が即時反映されないため、一時的な変数を作成
     // 関数内だとuseEffectが使えなかったため、この方法で対処した
     const tempPlayer1IsNext = step % 2 === 0;

--- a/src/pages/Settings.js
+++ b/src/pages/Settings.js
@@ -4,6 +4,7 @@ import Typography from "@mui/material/Typography";
 import Box from "@mui/material/Box";
 import Grid from "@mui/material/Grid";
 import TextField from "@mui/material/TextField";
+import InputAdornment from "@mui/material/InputAdornment";
 import Form from "../components/Form";
 import TransitionButton from "../components/TransitionButton";
 import "./settings.css";
@@ -130,6 +131,60 @@ const Settings = (props) => {
                   }}
                 />
               </>
+            }
+          />
+        </Grid>
+
+        <Grid container item alignItems="center" justifyContent="center">
+          <Form
+            label="Time Control"
+            input={
+              <Grid container alignItems="center" justifyContent="center">
+                <Grid item xs={6}>
+                  <TextField
+                    label="Minute"
+                    variant="outlined"
+                    type="number"
+                    onKeyDown={(evt) => evt.key === "e" && evt.preventDefault()}
+                    name="timeMinControl"
+                    value={props.timeMinControl}
+                    onChange={props.onNumberChange}
+                    InputLabelProps={{
+                      shrink: true,
+                    }}
+                    style={{ textAlign: "right", width: "90%" }}
+                    InputProps={{
+                      inputProps: {
+                        max: 60,
+                        min: 0,
+                      },
+                      endAdornment: <InputAdornment position="end">min</InputAdornment>,
+                    }}
+                  />
+                </Grid>
+                <Grid item xs={6}>
+                  <TextField
+                    label="Second"
+                    variant="outlined"
+                    type="number"
+                    onKeyDown={(evt) => evt.key === "e" && evt.preventDefault()}
+                    name="timeSecControl"
+                    value={props.timeSecControl}
+                    onChange={props.onNumberChange}
+                    InputLabelProps={{
+                      shrink: true,
+                    }}
+                    style={{ textAlign: "right", width: "90%" }}
+                    InputProps={{
+                      inputProps: {
+                        max: 60,
+                        min: 0,
+                      },
+                      endAdornment: <InputAdornment position="end">sec</InputAdornment>,
+                    }}
+                  />
+                </Grid>
+              </Grid>
             }
           />
         </Grid>

--- a/src/utils/displayTimer.js
+++ b/src/utils/displayTimer.js
@@ -1,18 +1,15 @@
 /**
  * タイマーの時間表示
  * @param {number} count
- * @returns タイマー表示（mm:ss.00）
+ * @returns タイマー表示（mm:ss）
  */
 const displayTimer = (count) => {
   if (count >= 0) {
-    const minute = Math.floor(count / 100 / 60);
+    const minute = Math.floor(count / 60);
     const displayMinute = minute >= 10 ? String(minute) : "0" + String(minute);
-    const second = count % (60 * 100);
-    const secondFront = Math.floor(second / 100);
-    const secondBack = second % 100;
-    const displaySecondFront = secondFront >= 10 ? String(secondFront) : "0" + String(secondFront);
-    const displaySecondBack = secondBack >= 10 ? String(secondBack) : "0" + String(secondBack);
-    return `${displayMinute}:${displaySecondFront}:${displaySecondBack}`;
+    const second = count % 60;
+    const displaySecond = second >= 10 ? String(second) : "0" + String(second);
+    return `${displayMinute}:${displaySecond}`;
   } else {
     return "Time is up!";
   }

--- a/src/utils/displayTimer.js
+++ b/src/utils/displayTimer.js
@@ -1,0 +1,21 @@
+/**
+ * タイマーの時間表示
+ * @param {number} count
+ * @returns タイマー表示（mm:ss.00）
+ */
+const displayTimer = (count) => {
+  if (count >= 0) {
+    const minute = Math.floor(count / 100 / 60);
+    const displayMinute = minute >= 10 ? String(minute) : "0" + String(minute);
+    const second = count % (60 * 100);
+    const secondFront = Math.floor(second / 100);
+    const secondBack = second % 100;
+    const displaySecondFront = secondFront >= 10 ? String(secondFront) : "0" + String(secondFront);
+    const displaySecondBack = secondBack >= 10 ? String(secondBack) : "0" + String(secondBack);
+    return `${displayMinute}:${displaySecondFront}:${displaySecondBack}`;
+  } else {
+    return "Time is up!";
+  }
+};
+
+export default displayTimer;

--- a/src/utils/useTimer.js
+++ b/src/utils/useTimer.js
@@ -1,0 +1,47 @@
+import { useState, useCallback, useRef } from "react";
+
+function useTimer(timeControl) {
+  const [count, setCount] = useState(timeControl);
+  const intervalRef = useRef(null);
+  /**
+   * タイマーの開始
+   */
+  const startTimer = useCallback(() => {
+    if (intervalRef.current !== null) {
+      return;
+    }
+    intervalRef.current = setInterval(() => {
+      setCount((c) => c - 1);
+    }, 1000);
+  }, []);
+
+  /**
+   * タイマーの停止
+   */
+  const stopTimer = useCallback(() => {
+    if (intervalRef.current === null) {
+      return;
+    }
+    clearInterval(intervalRef.current);
+    intervalRef.current = null;
+  }, []);
+
+  /**
+   * タイマーのリセット
+   */
+  const resetTimer = () => {
+    setCount(timeControl);
+  };
+
+  /**
+   * タイマーのセット
+   * @param {number} setTime - タイマーにセットする時間
+   */
+  const setTimer = (setTime) => {
+    setCount(setTime);
+  };
+
+  return [count, startTimer, stopTimer, resetTimer, setTimer];
+}
+
+export default useTimer;


### PR DESCRIPTION
持ち時間機能を追加しました。
- ホーム画面から遷移した直後にカウントダウンが始まらないように、START NEW GAMEを押してからゲームを開始するように変更しました
- 設定画面から持ち時間を変更することができます
- 先に持ち時間が無くなった方が負けです
- 手番を戻る際に、タイマーも元に戻るようにしています

タイマーを止めないまま、左上のボタンでページ遷移すると以下のエラーが出ます。左上のボタンにonClickでタイマーの停止を発動させたいですが、左上のボタンが全ページで共通化されているので、一旦保留にしています。

```
index.js:1 Warning: Can't perform a React state update on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in a useEffect cleanup function.
    at GameDisplayPage (http://localhost:3000/main.dd79cc315d45e3846b7b.hot-update.js:73:97)
```

close #24 