### PR TITLE
CPUが先行の時、startボタンを押す前に石が落ちてきてしまうバグを修正

### DIFF
--- a/src/pages/GameDisplayPage.js
+++ b/src/pages/GameDisplayPage.js
@@ -147,7 +147,7 @@ const GameDisplayPage = (props) => {
 
   const jumpTo = (step) => {
     setStepNumber(step);
-    let tempIsPlayer1Next = true;
+    let tempIsPlayer1Next;
     if (props.gameMode === "player") {
       tempIsPlayer1Next = step % 2 === 0;
       setIsPlayer1Next(tempIsPlayer1Next);

--- a/src/pages/GameDisplayPage.js
+++ b/src/pages/GameDisplayPage.js
@@ -18,6 +18,7 @@ import Cpu from "../utils/cpu";
 import createNewBoard from "../utils/createNewBoard";
 import displayTimer from "../utils/displayTimer";
 import getLowestEmptyYIndex from "../utils/getLowestEmptyYIndex";
+import isPlayerFirst from "../utils/isPlayerFirst";
 import useTimer from "../utils/useTimer";
 
 // import setSnackbarOpen from "../components/Snackbar";
@@ -41,10 +42,12 @@ const useStyles = makeStyles({
 });
 
 const GameDisplayPage = (props) => {
-  const initBoard = createNewBoard(props.boardSize[0], props.boardSize[1], props.gameMode);
+  const initBoard = createNewBoard(props.boardSize[0], props.boardSize[1]);
   const timeControl = props.timeMinControl * 60 + props.timeSecControl;
-
-  const [isPlayer1Next, setIsPlayer1Next] = useState(true);
+  const tempIsPlayer1NextInitialFlag = isPlayerFirst();
+  const [isPlayer1Next, setIsPlayer1Next] = useState(tempIsPlayer1NextInitialFlag);
+  const [IsPlayer1NextInitialFlag, setIsPlayer1NextInitialFlag] = useState(tempIsPlayer1NextInitialFlag);
+  const [ifInitGame, setIfInitGame] = useState(false);
   const [count1, startTimer1, stopTimer1, resetTimer1, setTimer1] = useTimer(timeControl);
   const [count2, startTimer2, stopTimer2, resetTimer2, setTimer2] = useTimer(timeControl);
   const [gameWinner, setGameWinner] = useState("");
@@ -83,6 +86,7 @@ const GameDisplayPage = (props) => {
    * ゲーム状態の初期化
    */
   const initGame = () => {
+    const tempIsPlayerFirst = isPlayerFirst();
     setHistory([
       {
         board: initBoard,
@@ -91,14 +95,16 @@ const GameDisplayPage = (props) => {
       },
     ]);
     setGameWinner("");
-    setIsPlayer1Next(true);
+    setIsPlayer1Next(tempIsPlayerFirst);
     setStepNumber(0);
     setCanStartGame(true);
     stopTimer1();
     stopTimer2();
     resetTimer1();
     resetTimer2();
-    startTimer1();
+    controlTimer(tempIsPlayerFirst);
+    setIsPlayer1NextInitialFlag(tempIsPlayerFirst);
+    setIfInitGame(!ifInitGame);
   };
 
   // historyを任意の手番に遡る際にhistoryを更新する
@@ -135,14 +141,24 @@ const GameDisplayPage = (props) => {
 
   const jumpTo = (step) => {
     setStepNumber(step);
-    setIsPlayer1Next(step % 2 === 0);
+    let tempIsPlayer1Next = true;
+    if (props.gameMode === "player") {
+      tempIsPlayer1Next = step % 2 === 0;
+      setIsPlayer1Next(tempIsPlayer1Next);
+    } else if (props.gameMode === "cpu") {
+      if (IsPlayer1NextInitialFlag === false) {
+        tempIsPlayer1Next = step % 2 !== 0;
+        setIsPlayer1Next(tempIsPlayer1Next);
+      } else {
+        tempIsPlayer1Next = step % 2 === 0;
+        setIsPlayer1Next(tempIsPlayer1Next);
+      }
+      setIfInitGame(!ifInitGame);
+    }
     setHistory(updateHistory(history, step));
     setGameWinner("");
     setTimer1(history[step].count1);
     setTimer2(history[step].count2);
-    // player1IsNextの情報が即時反映されないため、一時的な変数を作成
-    // 関数内だとuseEffectが使えなかったため、この方法で対処した
-    const tempIsPlayer1Next = step % 2 === 0;
     controlTimer(tempIsPlayer1Next);
   };
 
@@ -226,7 +242,43 @@ const GameDisplayPage = (props) => {
     }
   };
 
-  // cpuTurnをトリガーにcpuが石を打つ
+  // cpuが先攻の時、ifInitGame(initGameの実行で更新)をフラグにcpuが先に石を打つ
+  useEffect(() => {
+    const renewedHistory = copyHistory(history);
+    const currentBoard = renewedHistory[stepNumber].board;
+    const nextBoard = copyBoard(currentBoard);
+    const copiedCount1 = count1;
+    const copiedCount2 = count2;
+
+    if (props.gameMode === "cpu" && isPlayer1Next === false && gameStartModalOpen === false) {
+      setTimeout(() => {
+        const cpuX = getCpuX(nextBoard, props.victoryCondition, props.cpuStrength);
+        const cpuY = getLowestEmptyYIndex(nextBoard, cpuX);
+        nextBoard[cpuX][cpuY] = "Player2";
+        setHistory(
+          renewedHistory.concat([
+            {
+              board: nextBoard,
+              count1: copiedCount1,
+              count2: copiedCount2,
+            },
+          ])
+        );
+        setStepNumber(stepNumber + 1);
+        const tempPlayer1IsNext = !isPlayer1Next;
+        if (tempPlayer1IsNext) {
+          startTimer1();
+          stopTimer2();
+        } else {
+          stopTimer1();
+          startTimer2();
+        }
+        setIsPlayer1Next(!isPlayer1Next);
+      }, 3000);
+    }
+  }, [ifInitGame]);
+
+  // cpuTurnをフラグにcpuが石を打つ
   useEffect(() => {
     const renewedHistory = copyHistory(history);
     const currentBoard = renewedHistory[stepNumber].board;

--- a/src/utils/createNewBoard.js
+++ b/src/utils/createNewBoard.js
@@ -1,5 +1,3 @@
-import isPlayerFirst from "./isPlayerFirst";
-
 /**
  * Boardを新規作成する
  * @param {number} x - boardの幅
@@ -8,17 +6,10 @@ import isPlayerFirst from "./isPlayerFirst";
  * @return {string[][]} - 新規作成したboard
  */
 
-function createNewBoard(x, y, gameMode) {
+function createNewBoard(x, y) {
   const board = new Array(x);
   for (let i = 0; i < x; i++) {
     board[i] = new Array(y).fill(null);
-  }
-  // cpu対戦の時、プレイヤーが後攻だったら、ボードの初期状態をcpuが一石置いた状態にしておく。
-  if (gameMode === "cpu") {
-    if (isPlayerFirst() === false) {
-      const randomNumber = Math.floor(Math.random() * x);
-      board[randomNumber][0] = "Player2";
-    }
   }
   return board;
 }


### PR DESCRIPTION
cpuが先行の時、盤面の初期配列にあらかじめ"Player2"を一つランダムに代入して対応しておりましたが、それでは初期レンダリング時に石が落ちてきてしまうので今回のような動作になっていました。

修正後は、useEffectを使い、CPUが先行の時はstartボタンを押した後&&InitGame()を実行した後に石が落ちるようにしました。

レビューの方よろしくお願いいたします！